### PR TITLE
Update Printer model for culling fix

### DIFF
--- a/src/main/resources/assets/create_enchantment_industry/models/block/printer/block.json
+++ b/src/main/resources/assets/create_enchantment_industry/models/block/printer/block.json
@@ -13,11 +13,11 @@
 			"to": [14, 16, 14],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, -23]},
 			"faces": {
-				"north": {"uv": [1, 0, 7, 1], "texture": "#tank", "cullface": "north"},
-				"east": {"uv": [1, 0, 7, 1], "texture": "#tank", "cullface": "east"},
-				"south": {"uv": [1, 0, 7, 1], "texture": "#tank", "cullface": "south"},
-				"west": {"uv": [1, 0, 7, 1], "texture": "#tank", "cullface": "west"},
-				"up": {"uv": [1, 9, 7, 15], "texture": "#tank"}
+				"north": {"uv": [1, 0, 7, 1], "texture": "#tank"},
+				"east": {"uv": [1, 0, 7, 1], "texture": "#tank"},
+				"south": {"uv": [1, 0, 7, 1], "texture": "#tank"},
+				"west": {"uv": [1, 0, 7, 1], "texture": "#tank"},
+				"up": {"uv": [1, 9, 7, 15], "texture": "#tank", "cullface": "up"}
 			}
 		},
 		{
@@ -26,12 +26,12 @@
 			"to": [15, 14, 15],
 			"rotation": {"angle": 0, "axis": "y", "origin": [7, 6, -24]},
 			"faces": {
-				"north": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank", "cullface": "north"},
-				"east": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank", "cullface": "east"},
-				"south": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank", "cullface": "south"},
-				"west": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank", "cullface": "west"},
+				"north": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank"},
+				"east": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank"},
+				"south": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank"},
+				"west": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank"},
 				"up": {"uv": [0.5, 8.5, 7.5, 15.5], "texture": "#tank"},
-				"down": {"uv": [0.5, 8.5, 7.5, 15.5], "texture": "#tank", "cullface": "down"}
+				"down": {"uv": [0.5, 8.5, 7.5, 15.5], "texture": "#tank"}
 			}
 		},
 		{
@@ -40,10 +40,10 @@
 			"to": [14, 2, 14],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, -23]},
 			"faces": {
-				"north": {"uv": [1, 7, 7, 8], "texture": "#tank", "cullface": "north"},
-				"east": {"uv": [1, 7, 7, 8], "texture": "#tank", "cullface": "east"},
-				"south": {"uv": [1, 7, 7, 8], "texture": "#tank", "cullface": "south"},
-				"west": {"uv": [1, 7, 7, 8], "texture": "#tank", "cullface": "west"},
+				"north": {"uv": [1, 7, 7, 8], "texture": "#tank"},
+				"east": {"uv": [1, 7, 7, 8], "texture": "#tank"},
+				"south": {"uv": [1, 7, 7, 8], "texture": "#tank"},
+				"west": {"uv": [1, 7, 7, 8], "texture": "#tank"},
 				"down": {"uv": [9, 9, 15, 15], "texture": "#tank", "cullface": "down"}
 			}
 		},
@@ -53,12 +53,12 @@
 			"to": [15, 4, 15],
 			"rotation": {"angle": 0, "axis": "y", "origin": [7, -4, -24]},
 			"faces": {
-				"north": {"uv": [0.5, 6, 7.5, 7], "texture": "#tank", "cullface": "north"},
-				"east": {"uv": [1, 6, 7.5, 7], "texture": "#tank", "cullface": "east"},
-				"south": {"uv": [0.5, 6, 7.5, 7], "texture": "#tank", "cullface": "south"},
-				"west": {"uv": [0.5, 6, 7.5, 7], "texture": "#tank", "cullface": "west"},
+				"north": {"uv": [0.5, 6, 7.5, 7], "texture": "#tank"},
+				"east": {"uv": [1, 6, 7.5, 7], "texture": "#tank"},
+				"south": {"uv": [0.5, 6, 7.5, 7], "texture": "#tank"},
+				"west": {"uv": [0.5, 6, 7.5, 7], "texture": "#tank"},
 				"up": {"uv": [8.5, 8.5, 15.5, 15.5], "texture": "#tank"},
-				"down": {"uv": [0.5, 8.5, 7.5, 15.5], "texture": "#tank", "cullface": "down"}
+				"down": {"uv": [0.5, 8.5, 7.5, 15.5], "texture": "#tank"}
 			}
 		},
 		{
@@ -67,9 +67,9 @@
 			"to": [2, 12, 10],
 			"faces": {
 				"north": {"uv": [0, 0, 0, 0], "texture": "#tank"},
-				"east": {"uv": [9, 0, 11, 4], "texture": "#tank", "cullface": "west"},
+				"east": {"uv": [9, 0, 11, 4], "texture": "#tank"},
 				"south": {"uv": [0, 0, 0, 0], "texture": "#tank"},
-				"west": {"uv": [9, 0, 11, 4], "texture": "#tank", "cullface": "west"},
+				"west": {"uv": [9, 0, 11, 4], "texture": "#tank"},
 				"up": {"uv": [0, 0, 0, 0], "texture": "#tank"},
 				"down": {"uv": [0, 0, 0, 0], "texture": "#tank"}
 			}
@@ -79,10 +79,10 @@
 			"from": [6, 4, 2],
 			"to": [10, 12, 2],
 			"faces": {
-				"north": {"uv": [9, 0, 11, 4], "texture": "#tank", "cullface": "west"},
-				"east": {"uv": [0, 0, 0, 0], "texture": "#tank", "cullface": "west"},
-				"south": {"uv": [9, 0, 11, 4], "texture": "#tank", "cullface": "west"},
-				"west": {"uv": [0, 0, 0, 0], "texture": "#tank", "cullface": "west"},
+				"north": {"uv": [9, 0, 11, 4], "texture": "#tank"},
+				"east": {"uv": [0, 0, 0, 0], "texture": "#tank"},
+				"south": {"uv": [9, 0, 11, 4], "texture": "#tank"},
+				"west": {"uv": [0, 0, 0, 0], "texture": "#tank"},
 				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#tank"},
 				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#tank"}
 			}
@@ -92,10 +92,10 @@
 			"from": [14, 4, 6],
 			"to": [14, 12, 10],
 			"faces": {
-				"north": {"uv": [0, 0, 0, 0], "texture": "#tank", "cullface": "west"},
-				"east": {"uv": [9, 0, 11, 4], "texture": "#tank", "cullface": "west"},
-				"south": {"uv": [0, 0, 0, 0], "texture": "#tank", "cullface": "west"},
-				"west": {"uv": [9, 0, 11, 4], "texture": "#tank", "cullface": "west"},
+				"north": {"uv": [0, 0, 0, 0], "texture": "#tank"},
+				"east": {"uv": [9, 0, 11, 4], "texture": "#tank"},
+				"south": {"uv": [0, 0, 0, 0], "texture": "#tank"},
+				"west": {"uv": [9, 0, 11, 4], "texture": "#tank"},
 				"up": {"uv": [0, 0, 0, 0], "rotation": 180, "texture": "#tank"},
 				"down": {"uv": [0, 0, 0, 0], "rotation": 180, "texture": "#tank"}
 			}
@@ -105,10 +105,10 @@
 			"from": [6, 4, 14],
 			"to": [10, 12, 14],
 			"faces": {
-				"north": {"uv": [9, 0, 11, 4], "texture": "#tank", "cullface": "west"},
-				"east": {"uv": [0, 0, 0, 0], "texture": "#tank", "cullface": "west"},
-				"south": {"uv": [9, 0, 11, 4], "texture": "#tank", "cullface": "west"},
-				"west": {"uv": [0, 0, 0, 0], "texture": "#tank", "cullface": "west"},
+				"north": {"uv": [9, 0, 11, 4], "texture": "#tank"},
+				"east": {"uv": [0, 0, 0, 0], "texture": "#tank"},
+				"south": {"uv": [9, 0, 11, 4], "texture": "#tank"},
+				"west": {"uv": [0, 0, 0, 0], "texture": "#tank"},
 				"up": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#tank"},
 				"down": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#tank"}
 			}
@@ -118,9 +118,9 @@
 			"from": [1, 4, 1],
 			"to": [2, 12, 6],
 			"faces": {
-				"east": {"uv": [5, 2, 7.5, 6], "texture": "#tank", "cullface": "west"},
-				"south": {"uv": [7, 4.5, 7.5, 5], "texture": "#tank", "cullface": "west"},
-				"west": {"uv": [0.5, 2, 3, 6], "texture": "#tank", "cullface": "west"}
+				"east": {"uv": [5, 2, 7.5, 6], "texture": "#tank"},
+				"south": {"uv": [7, 4.5, 7.5, 5], "texture": "#tank"},
+				"west": {"uv": [0.5, 2, 3, 6], "texture": "#tank"}
 			}
 		},
 		{
@@ -128,9 +128,9 @@
 			"from": [10, 4, 1],
 			"to": [15, 12, 2],
 			"faces": {
-				"north": {"uv": [0.5, 2, 3, 6], "texture": "#tank", "cullface": "west"},
-				"south": {"uv": [5, 2, 7.5, 6], "texture": "#tank", "cullface": "west"},
-				"west": {"uv": [7, 4.5, 7.5, 5], "texture": "#tank", "cullface": "west"}
+				"north": {"uv": [0.5, 2, 3, 6], "texture": "#tank"},
+				"south": {"uv": [5, 2, 7.5, 6], "texture": "#tank"},
+				"west": {"uv": [7, 4.5, 7.5, 5], "texture": "#tank"}
 			}
 		},
 		{
@@ -138,9 +138,9 @@
 			"from": [14, 4, 10],
 			"to": [15, 12, 15],
 			"faces": {
-				"north": {"uv": [7, 4.5, 7.5, 5], "texture": "#tank", "cullface": "west"},
-				"east": {"uv": [0.5, 2, 3, 6], "texture": "#tank", "cullface": "west"},
-				"west": {"uv": [5, 2, 7.5, 6], "texture": "#tank", "cullface": "west"}
+				"north": {"uv": [7, 4.5, 7.5, 5], "texture": "#tank"},
+				"east": {"uv": [0.5, 2, 3, 6], "texture": "#tank"},
+				"west": {"uv": [5, 2, 7.5, 6], "texture": "#tank"}
 			}
 		},
 		{
@@ -148,9 +148,9 @@
 			"from": [1, 4, 14],
 			"to": [6, 12, 15],
 			"faces": {
-				"north": {"uv": [5, 2, 7.5, 6], "texture": "#tank", "cullface": "west"},
-				"east": {"uv": [7, 4.5, 7.5, 5], "texture": "#tank", "cullface": "west"},
-				"south": {"uv": [0.5, 2, 3, 6], "texture": "#tank", "cullface": "west"}
+				"north": {"uv": [5, 2, 7.5, 6], "texture": "#tank"},
+				"east": {"uv": [7, 4.5, 7.5, 5], "texture": "#tank"},
+				"south": {"uv": [0.5, 2, 3, 6], "texture": "#tank"}
 			}
 		},
 		{
@@ -158,9 +158,9 @@
 			"from": [1, 4, 10],
 			"to": [2, 12, 15],
 			"faces": {
-				"north": {"uv": [7, 3.5, 7.5, 4], "texture": "#tank", "cullface": "west"},
-				"east": {"uv": [0.5, 2, 3, 6], "texture": "#tank", "cullface": "west"},
-				"west": {"uv": [5, 2, 7.5, 6], "texture": "#tank", "cullface": "west"}
+				"north": {"uv": [7, 3.5, 7.5, 4], "texture": "#tank"},
+				"east": {"uv": [0.5, 2, 3, 6], "texture": "#tank"},
+				"west": {"uv": [5, 2, 7.5, 6], "texture": "#tank"}
 			}
 		},
 		{
@@ -168,9 +168,9 @@
 			"from": [1, 4, 1],
 			"to": [6, 12, 2],
 			"faces": {
-				"north": {"uv": [5, 2, 7.5, 6], "texture": "#tank", "cullface": "west"},
-				"east": {"uv": [7, 3.5, 7.5, 4], "texture": "#tank", "cullface": "west"},
-				"south": {"uv": [0.5, 2, 3, 6], "texture": "#tank", "cullface": "west"}
+				"north": {"uv": [5, 2, 7.5, 6], "texture": "#tank"},
+				"east": {"uv": [7, 3.5, 7.5, 4], "texture": "#tank"},
+				"south": {"uv": [0.5, 2, 3, 6], "texture": "#tank"}
 			}
 		},
 		{
@@ -178,9 +178,9 @@
 			"from": [14, 4, 1],
 			"to": [15, 12, 6],
 			"faces": {
-				"east": {"uv": [5, 2, 7.5, 6], "texture": "#tank", "cullface": "west"},
-				"south": {"uv": [7, 3.5, 7.5, 4], "texture": "#tank", "cullface": "west"},
-				"west": {"uv": [0.5, 2, 3, 6], "texture": "#tank", "cullface": "west"}
+				"east": {"uv": [5, 2, 7.5, 6], "texture": "#tank"},
+				"south": {"uv": [7, 3.5, 7.5, 4], "texture": "#tank"},
+				"west": {"uv": [0.5, 2, 3, 6], "texture": "#tank"}
 			}
 		},
 		{
@@ -188,9 +188,9 @@
 			"from": [10, 4, 14],
 			"to": [15, 12, 15],
 			"faces": {
-				"north": {"uv": [0.5, 2, 3, 6], "texture": "#tank", "cullface": "west"},
-				"south": {"uv": [5, 2, 7.5, 6], "texture": "#tank", "cullface": "west"},
-				"west": {"uv": [7, 3.5, 7.5, 4], "texture": "#tank", "cullface": "west"}
+				"north": {"uv": [0.5, 2, 3, 6], "texture": "#tank"},
+				"south": {"uv": [5, 2, 7.5, 6], "texture": "#tank"},
+				"west": {"uv": [7, 3.5, 7.5, 4], "texture": "#tank"}
 			}
 		}
 	],


### PR DESCRIPTION
Remove unnecessary face culling that caused visual issues on the block. This fixes an Issue where placing a block against the west face of the block would cause part of the model to disappear. This change also keeps other misc parts from culling when respective side is blocked, despite being able to still see the side.