### PR TITLE
Fixed index resetting of the Enchanting Guide

### DIFF
--- a/src/main/java/plus/dragons/createenchantmentindustry/content/contraptions/enchanting/enchanter/EnchantingGuideMenu.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/content/contraptions/enchanting/enchanter/EnchantingGuideMenu.java
@@ -25,6 +25,7 @@ import static plus.dragons.createenchantmentindustry.EnchantmentIndustry.LANG;
 
 public class EnchantingGuideMenu extends GhostItemContainer<ItemStack> {
     private static final Component NO_ENCHANTMENT = LANG.translate("gui.enchanting_guide.no_enchantment").component();
+    private ImmutableList<Component> previousEnchantments;
     ImmutableList<Component> enchantments = ImmutableList.of(NO_ENCHANTMENT);
     boolean directItemStackEdit;
     @Nullable
@@ -59,9 +60,11 @@ public class EnchantingGuideMenu extends GhostItemContainer<ItemStack> {
                     .map(entry -> entry.getKey().getFullname(entry.getValue()))
                     .toArray(Component[]::new)
             );
+        boolean resetIndex = previousEnchantments == null || !previousEnchantments.toString().equals(enchantments.toString());
+        previousEnchantments = ImmutableList.copyOf(enchantments);
         DistExecutor.unsafeRunWhenOn(Dist.CLIENT, () -> () -> {
             if (Minecraft.getInstance().screen instanceof EnchantingGuideScreen screen) {
-                screen.updateScrollInput();
+                screen.updateScrollInput(resetIndex);
             }
         });
     }

--- a/src/main/java/plus/dragons/createenchantmentindustry/content/contraptions/enchanting/enchanter/EnchantingGuideScreen.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/content/contraptions/enchanting/enchanter/EnchantingGuideScreen.java
@@ -37,8 +37,11 @@ public class EnchantingGuideScreen extends AbstractSimiContainerScreen<Enchantin
         blockPos = container.blockPos;
     }
 
-    public void updateScrollInput() {
-        index = 0;
+    public void updateScrollInput(boolean resetIndex) {
+        if (resetIndex) {
+            index = 0;
+        }
+
         scrollInput.forOptions(menu.enchantments);
         scrollInput.setState(index);
     }
@@ -63,7 +66,7 @@ public class EnchantingGuideScreen extends AbstractSimiContainerScreen<Enchantin
         scrollInput.calling(index -> this.index = index).writingTo(scrollInputLabel);
         addRenderableWidget(scrollInputLabel);
         addRenderableWidget(scrollInput);
-        updateScrollInput();
+        updateScrollInput(false);
     }
 
     @Override


### PR DESCRIPTION
Fixes #70

Tried to do it in 

https://github.com/DragonsPlusMinecraft/CreateEnchantmentIndustry/blob/3b712985bd84b7f5f45dfe3e1e405a5f5f678d9f/src/main/java/plus/dragons/createenchantmentindustry/content/contraptions/enchanting/enchanter/EnchantingGuideMenu.java#L126

but that seems to be unreliable to decide when to reset the index

Example:
https://streamable.com/w5b8j9