### PR TITLE
If an item already has an enchantment it can now be upgraded

### DIFF
--- a/src/main/java/plus/dragons/createenchantmentindustry/content/contraptions/enchanting/enchanter/Enchanting.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/content/contraptions/enchanting/enchanter/Enchanting.java
@@ -7,6 +7,8 @@ import net.minecraft.world.item.enchantment.EnchantmentHelper;
 import org.jetbrains.annotations.Nullable;
 import plus.dragons.createenchantmentindustry.entry.CeiItems;
 
+import java.util.Map;
+
 public class Enchanting {
 
     @Nullable
@@ -30,14 +32,22 @@ public class Enchanting {
         if (entry == null || !entry.valid())
             return null;
         var enchantment = entry.getFirst();
-        if (!enchantment.canEnchant(itemStack))
+
+        ItemStack toCheck = itemStack.copy();
+        Map<Enchantment, Integer> modified = EnchantmentHelper.getEnchantments(toCheck);
+
+        if (modified.containsKey(enchantment) && modified.get(enchantment) >= entry.getSecond()) {
             return null;
-        int level = entry.getSecond();
-        var map = EnchantmentHelper.getEnchantments(itemStack);
-        for (var e : map.entrySet()) {
+        }
+
+        // If the item already has the enchantment remove it to pass the checks
+        modified.remove(enchantment);
+        EnchantmentHelper.setEnchantments(modified, toCheck);
+
+        if (!enchantment.canEnchant(toCheck))
+            return null;
+        for (var e : modified.entrySet()) {
             if (!e.getKey().isCompatibleWith(enchantment))
-                return null;
-            if (e.getKey() == enchantment && e.getValue() >= entry.getSecond() + level)
                 return null;
         }
         return entry;


### PR DESCRIPTION
Fixes #83

Tested with:
* Item without enchantments
* Item with a lower version of said enchantment
* Item with an equal version of said enchantment (check is `>=` so it works with higher too I'd say)
* Item with other enchantments