### PR TITLE
Slightly improve build configs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,7 @@ void removeRedundant(jarTask){
 
 publishMods {
     file = tasks.jarJar.archiveFile
-    changelog = new File("changelog/${mod_version}.md").text
+    changelog = project.projectDir.toPath().resolve("changelog").resolve("${mod_version}.md").toFile().text
     version = mod_version
     type = STABLE
     displayName = "CEI ${mod_version} for Create ${minecraft_version}-${create_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ minecraft_version = 1.20.1
 forge_version = 47.0.43
 
 # build dependency versions
-forgegradle_version = 6.0.11
+forgegradle_version = [6.0, 6.2)
 mixingradle_version = 0.7-SNAPSHOT
 mixin_version = 0.8.5
 librarian_version = 1.+
@@ -22,7 +22,7 @@ create_version_build = 26
 flywheel_minecraft_version = 1.20.1
 flywheel_version = 0.6.10-7
 registrate_version = MC1.20-1.3.3
-create_dragon_lib_version = 1.4.2
+create_dragon_lib_version = 1.4.3
 create_dragon_lib_version_range = [1.4.1, 1.5.0)
 jei_minecraft_version = 1.20.1
 jei_version = 15.2.0.22


### PR DESCRIPTION
Hello, I recently tried to include your project on mine but there were 2 issues:
* dragon lib 1.4.2 is removed, there's only 1.4.3 on https://maven.dragons.plus/#/releases/plus/dragons/createdragonlib/create_dragon_lib-1.20.1
* It searches for changelog file from my project and not yours.
I admit 2nd one is only issue for me, but in case someone else also wants to include your project, could please you adjust path for it?

In the meantime I have also changed forge gradle version so it'd always fetch latest. I assumed it'd be better to use more recent version of FG.