### PR TITLE
Fixed the Printer textures for Create 6

### DIFF
--- a/src/main/resources/assets/create_enchantment_industry/models/block/printer/block.json
+++ b/src/main/resources/assets/create_enchantment_industry/models/block/printer/block.json
@@ -1,10 +1,13 @@
 {
-	"credit": "By LimonBlaze, made with Blockbench",
+	"credit": "By LimonBlaze, made with Blockbench, ported to Create 6.0 by Eric Oswald",
 	"parent": "block/block",
 	"render_type": "cutout_mipped",
 	"textures": {
 		"tank": "create:block/spout",
-		"particle": "create:block/copper_side"
+		"nozzle": "create:block/spout_nozzle",
+		"encased_pipe": "create:block/encased_pipe",
+		"drain": "create:block/item_drain_side",
+		"particle": "create:block/copper_underside"
 	},
 	"elements": [
 		{
@@ -17,7 +20,7 @@
 				"east": {"uv": [1, 0, 7, 1], "texture": "#tank"},
 				"south": {"uv": [1, 0, 7, 1], "texture": "#tank"},
 				"west": {"uv": [1, 0, 7, 1], "texture": "#tank"},
-				"up": {"uv": [1, 9, 7, 15], "texture": "#tank", "cullface": "up"}
+				"up": {"uv": [9, 9, 15, 15], "texture": "#tank", "cullface": "up"}
 			}
 		},
 		{
@@ -30,8 +33,8 @@
 				"east": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank"},
 				"south": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank"},
 				"west": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank"},
-				"up": {"uv": [0.5, 8.5, 7.5, 15.5], "texture": "#tank"},
-				"down": {"uv": [0.5, 8.5, 7.5, 15.5], "texture": "#tank"}
+				"up": {"uv": [8.5, 8.5, 15.5, 15.5], "texture": "#tank"},
+				"down": {"uv": [8.5, 8.5, 15.5, 15.5], "texture": "#tank"}
 			}
 		},
 		{
@@ -57,8 +60,7 @@
 				"east": {"uv": [1, 6, 7.5, 7], "texture": "#tank"},
 				"south": {"uv": [0.5, 6, 7.5, 7], "texture": "#tank"},
 				"west": {"uv": [0.5, 6, 7.5, 7], "texture": "#tank"},
-				"up": {"uv": [8.5, 8.5, 15.5, 15.5], "texture": "#tank"},
-				"down": {"uv": [0.5, 8.5, 7.5, 15.5], "texture": "#tank"}
+				"down": {"uv": [8.5, 8.5, 15.5, 15.5], "texture": "#tank"}
 			}
 		},
 		{
@@ -67,9 +69,9 @@
 			"to": [2, 12, 10],
 			"faces": {
 				"north": {"uv": [0, 0, 0, 0], "texture": "#tank"},
-				"east": {"uv": [9, 0, 11, 4], "texture": "#tank"},
+				"east": {"uv": [3, 2, 5, 6], "texture": "#tank"},
 				"south": {"uv": [0, 0, 0, 0], "texture": "#tank"},
-				"west": {"uv": [9, 0, 11, 4], "texture": "#tank"},
+				"west": {"uv": [3, 2, 5, 6], "texture": "#tank"},
 				"up": {"uv": [0, 0, 0, 0], "texture": "#tank"},
 				"down": {"uv": [0, 0, 0, 0], "texture": "#tank"}
 			}
@@ -78,10 +80,11 @@
 			"name": "Window",
 			"from": [6, 4, 2],
 			"to": [10, 12, 2],
+			"rotation": {"angle": 0, "axis": "y", "origin": [8, 1, 0]},
 			"faces": {
-				"north": {"uv": [9, 0, 11, 4], "texture": "#tank"},
+				"north": {"uv": [3, 2, 5, 6], "texture": "#tank"},
 				"east": {"uv": [0, 0, 0, 0], "texture": "#tank"},
-				"south": {"uv": [9, 0, 11, 4], "texture": "#tank"},
+				"south": {"uv": [3, 2, 5, 6], "texture": "#tank"},
 				"west": {"uv": [0, 0, 0, 0], "texture": "#tank"},
 				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#tank"},
 				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#tank"}
@@ -93,9 +96,9 @@
 			"to": [14, 12, 10],
 			"faces": {
 				"north": {"uv": [0, 0, 0, 0], "texture": "#tank"},
-				"east": {"uv": [9, 0, 11, 4], "texture": "#tank"},
+				"east": {"uv": [3, 2, 5, 6], "texture": "#tank"},
 				"south": {"uv": [0, 0, 0, 0], "texture": "#tank"},
-				"west": {"uv": [9, 0, 11, 4], "texture": "#tank"},
+				"west": {"uv": [3, 2, 5, 6], "texture": "#tank"},
 				"up": {"uv": [0, 0, 0, 0], "rotation": 180, "texture": "#tank"},
 				"down": {"uv": [0, 0, 0, 0], "rotation": 180, "texture": "#tank"}
 			}
@@ -105,9 +108,9 @@
 			"from": [6, 4, 14],
 			"to": [10, 12, 14],
 			"faces": {
-				"north": {"uv": [9, 0, 11, 4], "texture": "#tank"},
+				"north": {"uv": [3, 2, 5, 6], "texture": "#tank"},
 				"east": {"uv": [0, 0, 0, 0], "texture": "#tank"},
-				"south": {"uv": [9, 0, 11, 4], "texture": "#tank"},
+				"south": {"uv": [3, 2, 5, 6], "texture": "#tank"},
 				"west": {"uv": [0, 0, 0, 0], "texture": "#tank"},
 				"up": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#tank"},
 				"down": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#tank"}
@@ -192,6 +195,33 @@
 				"south": {"uv": [5, 2, 7.5, 6], "texture": "#tank"},
 				"west": {"uv": [7, 3.5, 7.5, 4], "texture": "#tank"}
 			}
+		},
+		{
+			"name": "UnderWindow",
+			"from": [1, 4, 6],
+			"to": [15, 4, 10],
+			"rotation": {"angle": 0, "axis": "y", "origin": [1, 3, 6]},
+			"faces": {
+				"up": {"uv": [11, 0.5, 13, 7.5], "rotation": 90, "texture": "#tank"}
+			}
+		},
+		{
+			"name": "UnderWindow",
+			"from": [6, 4, 1],
+			"to": [10, 4, 15],
+			"rotation": {"angle": 0, "axis": "y", "origin": [8, 3.5, 8]},
+			"faces": {
+				"up": {"uv": [11, 0.5, 13, 7.5], "texture": "#tank"}
+			}
+		},
+		{
+			"name": "EncasedPipe",
+			"from": [2, 4, 2],
+			"to": [14, 4, 14],
+			"rotation": {"angle": 0, "axis": "y", "origin": [0, 5, 7]},
+			"faces": {
+				"up": {"uv": [1, 1, 15, 15], "texture": "#encased_pipe"}
+			}
 		}
 	],
 	"display": {
@@ -231,7 +261,7 @@
 			"name": "tank",
 			"origin": [0, 0, 0],
 			"color": 0,
-			"children": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
+			"children": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18]
 		}
 	]
 }

--- a/src/main/resources/assets/create_enchantment_industry/models/block/printer/bottom.json
+++ b/src/main/resources/assets/create_enchantment_industry/models/block/printer/bottom.json
@@ -1,37 +1,25 @@
 {
-	"credit": "By LimonBlaze, made with Blockbench",
+	"credit": "By LimonBlaze, made with Blockbench, ported to Create 6.0 by Eric Oswald",
 	"parent": "block/block",
 	"textures": {
 		"head": "create:block/mechanical_press_head",
-		"particle": "create:block/copper_side",
-		"hose": "create:block/hose_pulley_coil"
+		"hose": "create:block/hose_pulley_coil",
+		"drain": "create:block/item_drain_side",
+		"particle": "create:block/copper_underside"
 	},
 	"elements": [
-		{
-			"name": "rope",
-			"from": [6, -7, 6],
-			"to": [10, 8, 10],
-			"rotation": {"angle": 0, "axis": "y", "origin": [7.75, 13, 8]},
-			"faces": {
-				"north": {"uv": [12, 0, 16, 16], "texture": "#hose"},
-				"east": {"uv": [12, 0, 16, 16], "texture": "#hose"},
-				"south": {"uv": [12, 0, 16, 16], "texture": "#hose"},
-				"west": {"uv": [12, 0, 16, 16], "texture": "#hose"},
-				"up": {"uv": [12, 0, 16, 4], "rotation": 90, "texture": "#hose"}
-			}
-		},
 		{
 			"name": "drain 2",
 			"from": [4.5, -7, 4.5],
 			"to": [11.5, -6, 11.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [6.75, 16, 6]},
 			"faces": {
-				"north": {"uv": [0, 1, 7, 2], "texture": "#hose"},
-				"east": {"uv": [0, 1, 7, 2], "texture": "#hose"},
-				"south": {"uv": [0, 1, 7, 2], "texture": "#hose"},
-				"west": {"uv": [0, 1, 7, 2], "texture": "#hose"},
-				"up": {"uv": [0, 2, 7, 9], "rotation": 90, "texture": "#hose"},
-				"down": {"uv": [0, 9, 7, 16], "texture": "#hose"}
+				"north": {"uv": [5, 8, 12, 9], "texture": "#drain"},
+				"east": {"uv": [5, 8, 12, 9], "texture": "#drain"},
+				"south": {"uv": [5, 8, 12, 9], "texture": "#drain"},
+				"west": {"uv": [5, 8, 12, 9], "texture": "#drain"},
+				"up": {"uv": [6, 4, 13, 11], "rotation": 90, "texture": "#particle"},
+				"down": {"uv": [0, 9, 7, 16], "texture": "#drain"}
 			}
 		},
 		{
@@ -40,12 +28,12 @@
 			"to": [10.5, -4, 10.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [7.75, 16, 7]},
 			"faces": {
-				"north": {"uv": [7, 2, 10, 7], "rotation": 270, "texture": "#hose"},
-				"east": {"uv": [7, 2, 10, 7], "rotation": 270, "texture": "#hose"},
-				"south": {"uv": [7, 2, 10, 7], "rotation": 270, "texture": "#hose"},
-				"west": {"uv": [7, 2, 10, 7], "rotation": 270, "texture": "#hose"},
-				"up": {"uv": [1, 3, 6, 8], "rotation": 90, "texture": "#hose"},
-				"down": {"uv": [0, 0, 0, 0], "texture": "#hose"}
+				"north": {"uv": [2, 6, 5, 11], "rotation": 270, "texture": "#drain"},
+				"east": {"uv": [2, 6, 5, 11], "rotation": 270, "texture": "#drain"},
+				"south": {"uv": [2, 6, 5, 11], "rotation": 270, "texture": "#drain"},
+				"west": {"uv": [2, 6, 5, 11], "rotation": 270, "texture": "#drain"},
+				"up": {"uv": [6, 6, 13, 13], "rotation": 90, "texture": "#drain"},
+				"down": {"uv": [0, 0, 0, 0], "texture": "#drain"}
 			}
 		},
 		{
@@ -59,6 +47,29 @@
 				"west": {"uv": [1, 0, 11, 4], "texture": "#head"},
 				"up": {"uv": [1, 5, 11, 15], "rotation": 180, "texture": "#head"},
 				"down": {"uv": [1, 5, 11, 15], "rotation": 180, "texture": "#head"}
+			}
+		},
+		{
+			"name": "Rope_lower",
+			"from": [6, -4, 6],
+			"to": [10, 5, 10],
+			"faces": {
+				"north": {"uv": [6, 0, 10, 9], "texture": "#hose"},
+				"east": {"uv": [6, 0, 10, 9], "texture": "#hose"},
+				"south": {"uv": [6, 0, 10, 9], "texture": "#hose"},
+				"west": {"uv": [6, 0, 10, 9], "texture": "#hose"}
+			}
+		},
+		{
+			"name": "Rope_upper",
+			"from": [6, 5, 6],
+			"to": [10, 8, 10],
+			"faces": {
+				"north": {"uv": [6, 13, 10, 16], "texture": "#hose"},
+				"east": {"uv": [6, 13, 10, 16], "texture": "#hose"},
+				"south": {"uv": [6, 13, 10, 16], "texture": "#hose"},
+				"west": {"uv": [6, 13, 10, 16], "texture": "#hose"},
+				"up": {"uv": [6, 3, 10, 7], "texture": "#hose"}
 			}
 		}
 	],
@@ -99,7 +110,7 @@
 			"name": "piston",
 			"origin": [0, 0, 0],
 			"color": 0,
-			"children": [0, 1, 2, 3]
+			"children": [0, 1, 2, 3, 4]
 		}
 	]
 }

--- a/src/main/resources/assets/create_enchantment_industry/models/block/printer/item.json
+++ b/src/main/resources/assets/create_enchantment_industry/models/block/printer/item.json
@@ -4,9 +4,12 @@
 	"render_type": "cutout_mipped",
 	"textures": {
 		"tank": "create:block/spout",
+		"encased_pipe": "create:block/encased_pipe",
 		"head": "create:block/mechanical_press_head",
-		"particle": "create:block/copper_side",
-		"hose": "create:block/hose_pulley_coil"
+		"particle": "create:block/copper_underside",
+		"hose": "create:block/hose_pulley_coil",
+		"drain": "create:block/item_drain_side",
+		"nozzle": "create:block/spout_nozzle"
 	},
 	"elements": [
 		{
@@ -15,11 +18,11 @@
 			"to": [14, 16, 14],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, -23]},
 			"faces": {
-				"north": {"uv": [1, 0, 7, 1], "texture": "#tank", "cullface": "north"},
-				"east": {"uv": [1, 0, 7, 1], "texture": "#tank", "cullface": "east"},
-				"south": {"uv": [1, 0, 7, 1], "texture": "#tank", "cullface": "south"},
-				"west": {"uv": [1, 0, 7, 1], "texture": "#tank", "cullface": "west"},
-				"up": {"uv": [1, 9, 7, 15], "texture": "#tank"}
+				"north": {"uv": [1, 0, 7, 1], "texture": "#tank"},
+				"east": {"uv": [1, 0, 7, 1], "texture": "#tank"},
+				"south": {"uv": [1, 0, 7, 1], "texture": "#tank"},
+				"west": {"uv": [1, 0, 7, 1], "texture": "#tank"},
+				"up": {"uv": [9, 9, 15, 15], "texture": "#tank", "cullface": "up"}
 			}
 		},
 		{
@@ -28,12 +31,12 @@
 			"to": [15, 14, 15],
 			"rotation": {"angle": 0, "axis": "y", "origin": [7, 6, -24]},
 			"faces": {
-				"north": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank", "cullface": "north"},
-				"east": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank", "cullface": "east"},
-				"south": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank", "cullface": "south"},
-				"west": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank", "cullface": "west"},
-				"up": {"uv": [0.5, 8.5, 7.5, 15.5], "texture": "#tank"},
-				"down": {"uv": [0.5, 8.5, 7.5, 15.5], "texture": "#tank", "cullface": "down"}
+				"north": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank"},
+				"east": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank"},
+				"south": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank"},
+				"west": {"uv": [0.5, 1, 7.5, 2], "texture": "#tank"},
+				"up": {"uv": [8.5, 8.5, 15.5, 15.5], "texture": "#tank"},
+				"down": {"uv": [8.5, 8.5, 15.5, 15.5], "texture": "#tank"}
 			}
 		},
 		{
@@ -42,10 +45,10 @@
 			"to": [14, 2, 14],
 			"rotation": {"angle": 0, "axis": "y", "origin": [8, 8, -23]},
 			"faces": {
-				"north": {"uv": [1, 7, 7, 8], "texture": "#tank", "cullface": "north"},
-				"east": {"uv": [1, 7, 7, 8], "texture": "#tank", "cullface": "east"},
-				"south": {"uv": [1, 7, 7, 8], "texture": "#tank", "cullface": "south"},
-				"west": {"uv": [1, 7, 7, 8], "texture": "#tank", "cullface": "west"},
+				"north": {"uv": [1, 7, 7, 8], "texture": "#tank"},
+				"east": {"uv": [1, 7, 7, 8], "texture": "#tank"},
+				"south": {"uv": [1, 7, 7, 8], "texture": "#tank"},
+				"west": {"uv": [1, 7, 7, 8], "texture": "#tank"},
 				"down": {"uv": [9, 9, 15, 15], "texture": "#tank", "cullface": "down"}
 			}
 		},
@@ -55,12 +58,11 @@
 			"to": [15, 4, 15],
 			"rotation": {"angle": 0, "axis": "y", "origin": [7, -4, -24]},
 			"faces": {
-				"north": {"uv": [0.5, 6, 7.5, 7], "texture": "#tank", "cullface": "north"},
-				"east": {"uv": [1, 6, 7.5, 7], "texture": "#tank", "cullface": "east"},
-				"south": {"uv": [0.5, 6, 7.5, 7], "texture": "#tank", "cullface": "south"},
-				"west": {"uv": [0.5, 6, 7.5, 7], "texture": "#tank", "cullface": "west"},
-				"up": {"uv": [8.5, 8.5, 15.5, 15.5], "texture": "#tank"},
-				"down": {"uv": [0.5, 8.5, 7.5, 15.5], "texture": "#tank", "cullface": "down"}
+				"north": {"uv": [0.5, 6, 7.5, 7], "texture": "#tank"},
+				"east": {"uv": [1, 6, 7.5, 7], "texture": "#tank"},
+				"south": {"uv": [0.5, 6, 7.5, 7], "texture": "#tank"},
+				"west": {"uv": [0.5, 6, 7.5, 7], "texture": "#tank"},
+				"down": {"uv": [8.5, 8.5, 15.5, 15.5], "texture": "#tank"}
 			}
 		},
 		{
@@ -69,9 +71,9 @@
 			"to": [2, 12, 10],
 			"faces": {
 				"north": {"uv": [0, 0, 0, 0], "texture": "#tank"},
-				"east": {"uv": [9, 0, 11, 4], "texture": "#tank", "cullface": "west"},
+				"east": {"uv": [3, 2, 5, 6], "texture": "#tank"},
 				"south": {"uv": [0, 0, 0, 0], "texture": "#tank"},
-				"west": {"uv": [9, 0, 11, 4], "texture": "#tank", "cullface": "west"},
+				"west": {"uv": [3, 2, 5, 6], "texture": "#tank"},
 				"up": {"uv": [0, 0, 0, 0], "texture": "#tank"},
 				"down": {"uv": [0, 0, 0, 0], "texture": "#tank"}
 			}
@@ -81,10 +83,10 @@
 			"from": [6, 4, 2],
 			"to": [10, 12, 2],
 			"faces": {
-				"north": {"uv": [9, 0, 11, 4], "texture": "#tank", "cullface": "west"},
-				"east": {"uv": [0, 0, 0, 0], "texture": "#tank", "cullface": "west"},
-				"south": {"uv": [9, 0, 11, 4], "texture": "#tank", "cullface": "west"},
-				"west": {"uv": [0, 0, 0, 0], "texture": "#tank", "cullface": "west"},
+				"north": {"uv": [3, 2, 5, 6], "texture": "#tank"},
+				"east": {"uv": [0, 0, 0, 0], "texture": "#tank"},
+				"south": {"uv": [3, 2, 5, 6], "texture": "#tank"},
+				"west": {"uv": [0, 0, 0, 0], "texture": "#tank"},
 				"up": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#tank"},
 				"down": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#tank"}
 			}
@@ -94,10 +96,10 @@
 			"from": [14, 4, 6],
 			"to": [14, 12, 10],
 			"faces": {
-				"north": {"uv": [0, 0, 0, 0], "texture": "#tank", "cullface": "west"},
-				"east": {"uv": [9, 0, 11, 4], "texture": "#tank", "cullface": "west"},
-				"south": {"uv": [0, 0, 0, 0], "texture": "#tank", "cullface": "west"},
-				"west": {"uv": [9, 0, 11, 4], "texture": "#tank", "cullface": "west"},
+				"north": {"uv": [0, 0, 0, 0], "texture": "#tank"},
+				"east": {"uv": [3, 2, 5, 6], "texture": "#tank"},
+				"south": {"uv": [0, 0, 0, 0], "texture": "#tank"},
+				"west": {"uv": [3, 2, 5, 6], "texture": "#tank"},
 				"up": {"uv": [0, 0, 0, 0], "rotation": 180, "texture": "#tank"},
 				"down": {"uv": [0, 0, 0, 0], "rotation": 180, "texture": "#tank"}
 			}
@@ -107,10 +109,10 @@
 			"from": [6, 4, 14],
 			"to": [10, 12, 14],
 			"faces": {
-				"north": {"uv": [9, 0, 11, 4], "texture": "#tank", "cullface": "west"},
-				"east": {"uv": [0, 0, 0, 0], "texture": "#tank", "cullface": "west"},
-				"south": {"uv": [9, 0, 11, 4], "texture": "#tank", "cullface": "west"},
-				"west": {"uv": [0, 0, 0, 0], "texture": "#tank", "cullface": "west"},
+				"north": {"uv": [3, 2, 5, 6], "texture": "#tank"},
+				"east": {"uv": [0, 0, 0, 0], "texture": "#tank"},
+				"south": {"uv": [3, 2, 5, 6], "texture": "#tank"},
+				"west": {"uv": [0, 0, 0, 0], "texture": "#tank"},
 				"up": {"uv": [0, 0, 0, 0], "rotation": 270, "texture": "#tank"},
 				"down": {"uv": [0, 0, 0, 0], "rotation": 90, "texture": "#tank"}
 			}
@@ -196,40 +198,79 @@
 			}
 		},
 		{
+			"name": "UnderWindow",
+			"from": [1, 4, 6],
+			"to": [15, 4, 10],
+			"rotation": {"angle": 0, "axis": "y", "origin": [1, 3, 6]},
+			"faces": {
+				"up": {"uv": [11, 0.5, 13, 7.5], "rotation": 90, "texture": "#tank"}
+			}
+		},
+		{
+			"name": "UnderWindow",
+			"from": [6, 4, 1],
+			"to": [10, 4, 15],
+			"rotation": {"angle": 0, "axis": "y", "origin": [8, 3.5, 8]},
+			"faces": {
+				"up": {"uv": [11, 0.5, 13, 7.5], "texture": "#tank"}
+			}
+		},
+		{
+			"name": "EncasedPipe",
+			"from": [2, 4, 2],
+			"to": [14, 4, 14],
+			"rotation": {"angle": 0, "axis": "y", "origin": [0, 5, 7]},
+			"faces": {
+				"up": {"uv": [1, 1, 15, 15], "texture": "#encased_pipe"}
+			}
+		},
+		{
+			"name": "top.json",
 			"from": [4, -2, 4],
 			"to": [12, 0, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [15.5, 5.5, 15.5]},
 			"faces": {
-				"north": {"uv": [12, 6, 16, 7], "texture": "#tank"},
-				"east": {"uv": [12, 6, 16, 7], "texture": "#tank"},
-				"south": {"uv": [12, 6, 16, 7], "texture": "#tank"},
-				"west": {"uv": [12, 6, 16, 7], "texture": "#tank"},
-				"down": {"uv": [12, 2, 16, 6], "texture": "#tank"}
+				"north": {"uv": [4, 12, 12, 14], "texture": "#nozzle"},
+				"east": {"uv": [4, 12, 12, 14], "texture": "#nozzle"},
+				"south": {"uv": [4, 12, 12, 14], "texture": "#nozzle"},
+				"west": {"uv": [4, 12, 12, 14], "texture": "#nozzle"},
+				"down": {"uv": [4, 4, 12, 12], "texture": "#nozzle"}
 			}
 		},
 		{
+			"name": "middle.json",
 			"from": [5, -4, 5],
 			"to": [11, -2, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [16.5, 3.5, 16.5]},
 			"faces": {
-				"north": {"uv": [12.5, 7, 15.5, 8], "texture": "#tank"},
-				"east": {"uv": [12.5, 7, 15.5, 8], "texture": "#tank"},
-				"south": {"uv": [12.5, 7, 15.5, 8], "texture": "#tank"},
-				"west": {"uv": [12.5, 7, 15.5, 8], "texture": "#tank"},
-				"down": {"uv": [12.5, 2.5, 15.5, 5.5], "texture": "#tank"}
+				"north": {"uv": [5, 14, 11, 16], "texture": "#nozzle"},
+				"east": {"uv": [5, 14, 11, 16], "texture": "#nozzle"},
+				"south": {"uv": [5, 14, 11, 16], "texture": "#nozzle"},
+				"west": {"uv": [5, 14, 11, 16], "texture": "#nozzle"},
+				"down": {"uv": [5, 5, 11, 11], "texture": "#nozzle"}
 			}
 		},
 		{
-			"name": "rope",
-			"from": [6, -7, 6],
-			"to": [10, 8, 10],
-			"rotation": {"angle": 0, "axis": "y", "origin": [7.75, 13, 8]},
+			"name": "Rope_lower",
+			"from": [6, -4, 6],
+			"to": [10, 5, 10],
 			"faces": {
-				"north": {"uv": [12, 0, 16, 16], "texture": "#hose"},
-				"east": {"uv": [12, 0, 16, 16], "texture": "#hose"},
-				"south": {"uv": [12, 0, 16, 16], "texture": "#hose"},
-				"west": {"uv": [12, 0, 16, 16], "texture": "#hose"},
-				"up": {"uv": [12, 0, 16, 4], "rotation": 90, "texture": "#hose"}
+				"north": {"uv": [6, 0, 10, 9], "texture": "#hose"},
+				"east": {"uv": [6, 0, 10, 9], "texture": "#hose"},
+				"south": {"uv": [6, 0, 10, 9], "texture": "#hose"},
+				"west": {"uv": [6, 0, 10, 9], "texture": "#hose"}
+			}
+		},
+		{
+			"name": "Rope_upper",
+			"from": [6, 5, 6],
+			"to": [10, 8, 10],
+			"faces": {
+				"north": {"uv": [6, 13, 10, 16], "texture": "#hose"},
+				"east": {"uv": [6, 13, 10, 16], "texture": "#hose"},
+				"south": {"uv": [6, 13, 10, 16], "texture": "#hose"},
+				"west": {"uv": [6, 13, 10, 16], "texture": "#hose"},
+				"up": {"uv": [6, 3, 10, 7], "texture": "#hose"}
 			}
 		},
 		{
@@ -238,12 +279,12 @@
 			"to": [11.5, -6, 11.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [6.75, 16, 6]},
 			"faces": {
-				"north": {"uv": [0, 1, 7, 2], "texture": "#hose"},
-				"east": {"uv": [0, 1, 7, 2], "texture": "#hose"},
-				"south": {"uv": [0, 1, 7, 2], "texture": "#hose"},
-				"west": {"uv": [0, 1, 7, 2], "texture": "#hose"},
-				"up": {"uv": [0, 2, 7, 9], "rotation": 90, "texture": "#hose"},
-				"down": {"uv": [0, 9, 7, 16], "texture": "#hose"}
+				"north": {"uv": [5, 8, 12, 9], "texture": "#drain"},
+				"east": {"uv": [5, 8, 12, 9], "texture": "#drain"},
+				"south": {"uv": [5, 8, 12, 9], "texture": "#drain"},
+				"west": {"uv": [5, 8, 12, 9], "texture": "#drain"},
+				"up": {"uv": [6, 4, 13, 11], "rotation": 90, "texture": "#particle"},
+				"down": {"uv": [0, 9, 7, 16], "texture": "#drain"}
 			}
 		},
 		{
@@ -252,12 +293,12 @@
 			"to": [10.5, -4, 10.5],
 			"rotation": {"angle": 0, "axis": "y", "origin": [7.75, 16, 7]},
 			"faces": {
-				"north": {"uv": [7, 2, 10, 7], "rotation": 270, "texture": "#hose"},
-				"east": {"uv": [7, 2, 10, 7], "rotation": 270, "texture": "#hose"},
-				"south": {"uv": [7, 2, 10, 7], "rotation": 270, "texture": "#hose"},
-				"west": {"uv": [7, 2, 10, 7], "rotation": 270, "texture": "#hose"},
-				"up": {"uv": [1, 3, 6, 8], "rotation": 90, "texture": "#hose"},
-				"down": {"uv": [0, 0, 0, 0], "texture": "#hose"}
+				"north": {"uv": [2, 6, 5, 11], "rotation": 270, "texture": "#drain"},
+				"east": {"uv": [2, 6, 5, 11], "rotation": 270, "texture": "#drain"},
+				"south": {"uv": [2, 6, 5, 11], "rotation": 270, "texture": "#drain"},
+				"west": {"uv": [2, 6, 5, 11], "rotation": 270, "texture": "#drain"},
+				"up": {"uv": [6, 6, 13, 13], "rotation": 90, "texture": "#drain"},
+				"down": {"uv": [0, 0, 0, 0], "texture": "#drain"}
 			}
 		},
 		{

--- a/src/main/resources/assets/create_enchantment_industry/models/block/printer/middle.json
+++ b/src/main/resources/assets/create_enchantment_industry/models/block/printer/middle.json
@@ -1,9 +1,9 @@
 {
-	"credit": "By LimonBlaze, made with Blockbench",
+	"credit": "By LimonBlaze, made with Blockbench, ported to Create 6.0 by Eric Oswald",
 	"parent": "block/block",
 	"textures": {
-		"tank": "create:block/spout",
-		"particle": "create:block/copper_side"
+		"nozzle": "create:block/spout_nozzle",
+		"particle": "create:block/copper_underside"
 	},
 	"elements": [
 		{
@@ -11,11 +11,11 @@
 			"to": [11, -2, 11],
 			"rotation": {"angle": 0, "axis": "y", "origin": [16.5, 3.5, 16.5]},
 			"faces": {
-				"north": {"uv": [12.5, 7, 15.5, 8], "texture": "#tank"},
-				"east": {"uv": [12.5, 7, 15.5, 8], "texture": "#tank"},
-				"south": {"uv": [12.5, 7, 15.5, 8], "texture": "#tank"},
-				"west": {"uv": [12.5, 7, 15.5, 8], "texture": "#tank"},
-				"down": {"uv": [12.5, 2.5, 15.5, 5.5], "texture": "#tank"}
+				"north": {"uv": [5, 14, 11, 16], "texture": "#nozzle"},
+				"east": {"uv": [5, 14, 11, 16], "texture": "#nozzle"},
+				"south": {"uv": [5, 14, 11, 16], "texture": "#nozzle"},
+				"west": {"uv": [5, 14, 11, 16], "texture": "#nozzle"},
+				"down": {"uv": [5, 5, 11, 11], "texture": "#nozzle"}
 			}
 		}
 	],

--- a/src/main/resources/assets/create_enchantment_industry/models/block/printer/top.json
+++ b/src/main/resources/assets/create_enchantment_industry/models/block/printer/top.json
@@ -1,10 +1,10 @@
 {
-	"credit": "By LimonBlaze, made with Blockbench",
+	"credit": "By LimonBlaze, made with Blockbench, ported to Create 6.0 by Eric Oswald",
 	"parent": "block/block",
 	"render_type": "cutout_mipped",
 	"textures": {
-		"tank": "create:block/spout",
-		"particle": "create:block/copper_side"
+		"nozzle": "create:block/spout_nozzle",
+		"particle": "create:block/copper_underside"
 	},
 	"elements": [
 		{
@@ -12,11 +12,11 @@
 			"to": [12, 0, 12],
 			"rotation": {"angle": 0, "axis": "y", "origin": [15.5, 5.5, 15.5]},
 			"faces": {
-				"north": {"uv": [12, 6, 16, 7], "texture": "#tank"},
-				"east": {"uv": [12, 6, 16, 7], "texture": "#tank"},
-				"south": {"uv": [12, 6, 16, 7], "texture": "#tank"},
-				"west": {"uv": [12, 6, 16, 7], "texture": "#tank"},
-				"down": {"uv": [12, 2, 16, 6], "texture": "#tank"}
+				"north": {"uv": [4, 12, 12, 14], "texture": "#nozzle"},
+				"east": {"uv": [4, 12, 12, 14], "texture": "#nozzle"},
+				"south": {"uv": [4, 12, 12, 14], "texture": "#nozzle"},
+				"west": {"uv": [4, 12, 12, 14], "texture": "#nozzle"},
+				"down": {"uv": [4, 4, 12, 12], "texture": "#nozzle"}
 			}
 		}
 	],


### PR DESCRIPTION
I've fixed the printer textures to use the Create 6 textures properly.
The result looks 1:1 to the printer in the old version - the only small change is the texture for
the copper parts at the bottom.
I couldn't find the exact same texture that was in the old Create version, so I used one that looks similar.
The change should go unnoticed by players.

Here is a screenshot of the patched printer ingame:
![Screenshot 2025-03-07 032337](https://github.com/user-attachments/assets/48c8a5d1-450a-4b70-bcc8-99c70590b695)
