### PR TITLE
Add milling/crushing recipes for sculk items

### DIFF
--- a/src/main/resources/data/create_enchantment_industry/recipes/milling/5xp_sculk_milling.json
+++ b/src/main/resources/data/create_enchantment_industry/recipes/milling/5xp_sculk_milling.json
@@ -1,0 +1,18 @@
+{
+    "type": "create:milling",
+    "ingredients": [
+        {
+            "tag": "create_enchantment_industry:sculk_five_xp"
+        }
+    ],
+    "results": [
+        {
+            "item": "create:experience_nugget"
+        },
+        {
+            "item": "create:experience_nugget",
+            "chance": 0.67
+        }
+    ],
+    "processingTime": 100
+}

--- a/src/main/resources/data/create_enchantment_industry/recipes/milling/sculk_milling.json
+++ b/src/main/resources/data/create_enchantment_industry/recipes/milling/sculk_milling.json
@@ -1,0 +1,15 @@
+{
+    "type": "create:milling",
+    "ingredients": [
+        {
+            "item": "minecraft:sculk"
+        }
+    ],
+    "results": [
+        {
+            "item": "create:experience_nugget",
+            "chance": 0.33
+        }
+    ],
+    "processingTime": 100
+}

--- a/src/main/resources/data/create_enchantment_industry/tags/items/sculk_five_xp.json
+++ b/src/main/resources/data/create_enchantment_industry/tags/items/sculk_five_xp.json
@@ -1,0 +1,8 @@
+{
+    "values": [
+        "minecraft:sculk_catalyst",
+        "minecraft:sculk_sensor",
+        "minecraft:calibrated_sculk_sensor",
+        "minecraft:sculk_shrieker"
+    ]
+}


### PR DESCRIPTION
On average, these drop as much experience as they do when mined without silk touch, but the result is no longer exactly guaranteed.

This is related to #190, although possibly the disenchanter should also be able to handle sculk, for precise liquid xp instead of approximate nuggets.

I have not yet tested this; it works as a separate datapack but I havenʼt tried putting running it as part of the mod.  Iʼll try that tomorrow, but half the time I try to build Java stuff I run into build errors nobody else has heard of, so no promises on getting useful test results.