### PR TITLE
Update `experience_cake_slice.json`

### DIFF
--- a/src/main/resources/data/create_enchantment_industry/recipe/cutting/farmersdelight/experience_cake_slice.json
+++ b/src/main/resources/data/create_enchantment_industry/recipe/cutting/farmersdelight/experience_cake_slice.json
@@ -13,8 +13,10 @@
   ],
   "result": [
     {
-      "count": 4,
-      "item": "create_enchantment_industry:experience_cake_slice"
+      "item": {
+        "count": 4,
+        "id": "create_enchantment_industry:experience_cake_slice"
+      }
     }
   ],
   "tool": {


### PR DESCRIPTION
- Fixed `Farmer's Delight` cutting recipe format by adding structure with `id` instead of just `item`.

Fixes this error:
```log
[Render thread/ERROR] [net.minecraft.world.item.crafting.RecipeManager/]: Parsing error loading recipe create_enchantment_industry:cutting/farmersdelight/experience_cake_slice: com.google.gson.JsonParseException: Not a JSON object: "create_enchantment_industry:experience_cake_slice"
```