### PR TITLE
Make Experience Lanterns pull in experience orbs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+	"java.compile.nullAnalysis.mode": "automatic",
+	"java.configuration.updateBuildConfiguration": "interactive"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-	"java.compile.nullAnalysis.mode": "automatic",
-	"java.configuration.updateBuildConfiguration": "interactive"
-}

--- a/src/main/java/plus/dragons/createenchantmentindustry/common/fluids/lantern/ExperienceLanternBlockEntity.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/common/fluids/lantern/ExperienceLanternBlockEntity.java
@@ -136,8 +136,8 @@ public class ExperienceLanternBlockEntity extends SmartBlockEntity implements IH
         if (!experienceOrbs.isEmpty()) {
             for (var orb : experienceOrbs) {
                 if (orb.getDeltaMovement().length() <= .5) {
-                    var pushForce = CEIConfig.fluids().experienceLanternPullForceMultiplier.get() * 1 / orb.getPosition(lazyTickCounter).distanceTo(getBlockPos().getCenter());
-                    var directionToLantern = getBlockPos().getCenter().subtract(orb.getPosition(lazyTickCounter)).normalize().multiply(pushForce, pushForce, pushForce);
+                    var pushForce = CEIConfig.fluids().experienceLanternPullForceMultiplier.get() * 1 / orb.position().distanceTo(getBlockPos().getCenter());
+                    var directionToLantern = getBlockPos().getCenter().subtract(orb.position()).normalize().multiply(pushForce, pushForce, pushForce);
                     orb.push(directionToLantern);
                 }
             }

--- a/src/main/java/plus/dragons/createenchantmentindustry/common/fluids/lantern/ExperienceLanternBlockEntity.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/common/fluids/lantern/ExperienceLanternBlockEntity.java
@@ -67,6 +67,9 @@ public class ExperienceLanternBlockEntity extends SmartBlockEntity implements IH
         if (!level.isClientSide && level.getGameTime() % 10 == 0) {
             drainExp();
         }
+        if (!level.isClientSide) {
+            pullExp();
+        }
     }
 
     public FluidTankBehaviour getTank() {
@@ -123,6 +126,20 @@ public class ExperienceLanternBlockEntity extends SmartBlockEntity implements IH
                         orb.value -= inserted;
                     }
                     break;
+                }
+            }
+        }
+    }
+
+    protected void pullExp() {
+        // Pull orbs toward the lantern
+        List<ExperienceOrb> experienceOrbs = level.getEntitiesOfClass(ExperienceOrb.class, effectiveAABB.inflate(CEIConfig.fluids().experienceLanternPullRadius.get()));
+        if (!experienceOrbs.isEmpty()) {
+            for (var orb : experienceOrbs) {
+                if (orb.getDeltaMovement().length() <= .5) {
+                    var pushForce = CEIConfig.fluids().experienceLanternPullForceMultiplier.get() * 1 / orb.getPosition(lazyTickCounter).distanceTo(getBlockPos().getCenter());
+                    var directionToLantern = getBlockPos().getCenter().subtract(orb.getPosition(lazyTickCounter)).normalize().multiply(pushForce, pushForce, pushForce);
+                    orb.push(directionToLantern);
                 }
             }
         }

--- a/src/main/java/plus/dragons/createenchantmentindustry/common/fluids/lantern/ExperienceLanternBlockEntity.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/common/fluids/lantern/ExperienceLanternBlockEntity.java
@@ -67,7 +67,7 @@ public class ExperienceLanternBlockEntity extends SmartBlockEntity implements IH
         if (!level.isClientSide && level.getGameTime() % 10 == 0) {
             drainExp();
         }
-        if (!level.isClientSide) {
+        if (!level.isClientSide && CEIConfig.fluids().experienceLanternPullToggle.get()) {
             pullExp();
         }
     }
@@ -132,7 +132,6 @@ public class ExperienceLanternBlockEntity extends SmartBlockEntity implements IH
     }
 
     protected void pullExp() {
-        // Pull orbs toward the lantern
         List<ExperienceOrb> experienceOrbs = level.getEntitiesOfClass(ExperienceOrb.class, effectiveAABB.inflate(CEIConfig.fluids().experienceLanternPullRadius.get()));
         if (!experienceOrbs.isEmpty()) {
             for (var orb : experienceOrbs) {

--- a/src/main/java/plus/dragons/createenchantmentindustry/common/fluids/lantern/ExperienceLanternMovementBehavior.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/common/fluids/lantern/ExperienceLanternMovementBehavior.java
@@ -28,6 +28,7 @@ import net.minecraft.world.entity.ExperienceOrb;
 import net.minecraft.world.entity.player.Player;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.phys.AABB;
+import net.minecraft.world.phys.Vec3;
 import net.neoforged.neoforge.fluids.FluidStack;
 import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import plus.dragons.createenchantmentindustry.common.fluids.experience.ExperienceHelper;
@@ -37,10 +38,16 @@ import plus.dragons.createenchantmentindustry.config.CEIConfig;
 public class ExperienceLanternMovementBehavior implements MovementBehaviour {
     @Override
     public void tick(MovementContext context) {
+        var effectiveAABB = new AABB(context.position.subtract(0.5d, 0.5d, 0.5d), context.position.add(0.5d, 0.5d, 0.5d)).inflate(0.5);
         if (!context.world.isClientSide && context.world.getGameTime() % 10 == 0) {
             drainExp(context.world,
-                    new AABB(context.position.subtract(0.5d, 0.5d, 0.5d), context.position.add(0.5d, 0.5d, 0.5d)).inflate(0.5),
+                    effectiveAABB,
                     context.contraption.getStorage().getFluids());
+        }
+        if (!context.world.isClientSide) {
+            pullExp(context.world,
+                    effectiveAABB,
+                    context.position);
         }
     }
 
@@ -95,6 +102,20 @@ public class ExperienceLanternMovementBehavior implements MovementBehaviour {
                         orb.value -= inserted;
                     }
                     break;
+                }
+            }
+        }
+    }
+
+    protected void pullExp(Level level, AABB effectiveAABB, Vec3 position) {
+        // Pull orbs toward the lantern
+        List<ExperienceOrb> experienceOrbs = level.getEntitiesOfClass(ExperienceOrb.class, effectiveAABB.inflate(CEIConfig.fluids().experienceLanternPullRadius.get()));
+        if (!experienceOrbs.isEmpty()) {
+            for (var orb : experienceOrbs) {
+                if (orb.getDeltaMovement().length() <= .5) {
+                    var pushForce = CEIConfig.fluids().experienceLanternPullForceMultiplier.get() * 1 / orb.position().distanceTo(position);
+                    var directionToLantern = position.subtract(orb.getPosition(1)).normalize().multiply(pushForce, pushForce, pushForce);
+                    orb.push(directionToLantern);
                 }
             }
         }

--- a/src/main/java/plus/dragons/createenchantmentindustry/common/fluids/lantern/ExperienceLanternMovementBehavior.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/common/fluids/lantern/ExperienceLanternMovementBehavior.java
@@ -44,7 +44,7 @@ public class ExperienceLanternMovementBehavior implements MovementBehaviour {
                     effectiveAABB,
                     context.contraption.getStorage().getFluids());
         }
-        if (!context.world.isClientSide) {
+        if (!context.world.isClientSide && CEIConfig.fluids().experienceLanternPullToggle.get()) {
             pullExp(context.world,
                     effectiveAABB,
                     context.position);
@@ -108,7 +108,6 @@ public class ExperienceLanternMovementBehavior implements MovementBehaviour {
     }
 
     protected void pullExp(Level level, AABB effectiveAABB, Vec3 position) {
-        // Pull orbs toward the lantern
         List<ExperienceOrb> experienceOrbs = level.getEntitiesOfClass(ExperienceOrb.class, effectiveAABB.inflate(CEIConfig.fluids().experienceLanternPullRadius.get()));
         if (!experienceOrbs.isEmpty()) {
             for (var orb : experienceOrbs) {

--- a/src/main/java/plus/dragons/createenchantmentindustry/common/fluids/lantern/ExperienceLanternMovementBehavior.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/common/fluids/lantern/ExperienceLanternMovementBehavior.java
@@ -113,7 +113,7 @@ public class ExperienceLanternMovementBehavior implements MovementBehaviour {
             for (var orb : experienceOrbs) {
                 if (orb.getDeltaMovement().length() <= .5) {
                     var pushForce = CEIConfig.fluids().experienceLanternPullForceMultiplier.get() * 1 / orb.position().distanceTo(position);
-                    var directionToLantern = position.subtract(orb.getPosition(1)).normalize().multiply(pushForce, pushForce, pushForce);
+                    var directionToLantern = position.subtract(orb.position()).normalize().multiply(pushForce, pushForce, pushForce);
                     orb.push(directionToLantern);
                 }
             }

--- a/src/main/java/plus/dragons/createenchantmentindustry/config/CEIFluidsConfig.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/config/CEIFluidsConfig.java
@@ -81,6 +81,9 @@ public class CEIFluidsConfig extends ConfigBase {
             "experienceLanternDrainRate",
             Comments.experienceLanternDrainRate,
             RequiresRestart.SERVER.asComment());
+    public final ConfigBool experienceLanternPullToggle = b(true,
+            "experienceLanternPullToggle",
+            Comments.experienceLanternPullToggle);
     public final ConfigInt experienceLanternPullRadius = i(10, 0,
             "experienceLanternPullRadius",
             Comments.experienceLanternPullRadius);
@@ -112,7 +115,8 @@ public class CEIFluidsConfig extends ConfigBase {
         static final String blazeForgerFluidCapacity = "The amount of liquid a Blaze Forger can hold (mB).";
         static final String experienceLanternFluidCapacity = "The amount of liquid an Experience Lantern can hold (mB).";
         static final String experienceLanternDrainRate = "The amount of experience an Experience Lantern can drain from player per 0.5 ticks (mB).";
+        static final String experienceLanternPullToggle = "Whether the Experience Lantern will pull in experience orbs from nearby.";
         static final String experienceLanternPullRadius = "The range at which experience orbs will be pulled into the lantern.";
-        static final String experienceLanternPullForceMultiplier = "Modifier for the amount of force to pull the experience orbs with";
+        static final String experienceLanternPullForceMultiplier = "Modifier for the amount of force with which to pull the experience orbs.";
     }
 }

--- a/src/main/java/plus/dragons/createenchantmentindustry/config/CEIFluidsConfig.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/config/CEIFluidsConfig.java
@@ -81,6 +81,12 @@ public class CEIFluidsConfig extends ConfigBase {
             "experienceLanternDrainRate",
             Comments.experienceLanternDrainRate,
             RequiresRestart.SERVER.asComment());
+    public final ConfigInt experienceLanternPullRadius = i(10, 0,
+            "experienceLanternPullRadius",
+            Comments.experienceLanternPullRadius);
+    public final ConfigFloat experienceLanternPullForceMultiplier = f(.075f, 0.0f, .5f,
+            "experienceLanternPullForceMultiplier",
+            Comments.experienceLanternPullForceMultiplier);
 
     @Override
     public String getName() {
@@ -106,5 +112,7 @@ public class CEIFluidsConfig extends ConfigBase {
         static final String blazeForgerFluidCapacity = "The amount of liquid a Blaze Forger can hold (mB).";
         static final String experienceLanternFluidCapacity = "The amount of liquid an Experience Lantern can hold (mB).";
         static final String experienceLanternDrainRate = "The amount of experience an Experience Lantern can drain from player per 0.5 ticks (mB).";
+        static final String experienceLanternPullRadius = "The range at which experience orbs will be pulled into the lantern.";
+        static final String experienceLanternPullForceMultiplier = "Modifier for the amount of force to pull the experience orbs with";
     }
 }


### PR DESCRIPTION
The lanterns can pull exp orbs from a configurable distance with an amount of force inversely proportional to their distance from the lantern (with a configurable modifier).