### PR TITLE
Remove refmap

### DIFF
--- a/src/main/resources/create_enchantment_industry.mixins.json
+++ b/src/main/resources/create_enchantment_industry.mixins.json
@@ -3,7 +3,6 @@
   "priority": 1100,
   "package": "plus.dragons.createenchantmentindustry.mixin",
   "compatibilityLevel": "JAVA_16",
-  "refmap": "create_enchantment_industry.refmap.json",
   "mixins": [
     "ConnectivityHandlerMixin",
     "CreateNBTProcessorsMixin",


### PR DESCRIPTION
NeoForge don't need refmaps and it only causes warning in the logs.