### PR TITLE
use partial ticks for smooth enchanted item rotations

### DIFF
--- a/src/main/java/plus/dragons/createenchantmentindustry/common/processing/enchanter/BlazeEnchanterRenderer.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/common/processing/enchanter/BlazeEnchanterRenderer.java
@@ -54,7 +54,7 @@ public class BlazeEnchanterRenderer extends BlazeBlockRenderer<BlazeEnchanterBlo
         Level level = blockEntity.getLevel();
         assert level != null;
         var blockPos = blockEntity.getBlockPos();
-        float renderTicks = AnimationTickHolder.getTicks(level);
+        float renderTicks = AnimationTickHolder.getTicks(level) + partialTicks;
         float animation = processingTime == -1
                 ? 0
                 : Mth.sin((processingTime + partialTicks) / 20f);

--- a/src/main/java/plus/dragons/createenchantmentindustry/common/processing/forger/BlazeForgerRenderer.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/common/processing/forger/BlazeForgerRenderer.java
@@ -56,7 +56,7 @@ public class BlazeForgerRenderer extends BlazeBlockRenderer<BlazeForgerBlockEnti
         Level level = blockEntity.getLevel();
         assert level != null;
         var blockPos = blockEntity.getBlockPos();
-        float renderTicks = AnimationTickHolder.getTicks(level);
+        float renderTicks = AnimationTickHolder.getTicks(level) + partialTicks;
         float animation = processingTime == -1
                 ? Mth.sin(slot * Mth.PI / -2f)
                 : Mth.sin((processingTime + partialTicks) / 20f + slot * Mth.PI);


### PR DESCRIPTION
I noticed that animations for items above the blaze forger and blaze enchanter are choppy. Upon inspecting the code I found that `xRot` and `zRot` in blaze renderers do not use partial ticks.

This PR fixes the problem by adding partial ticks to `renderTicks`.

Tested in game and the animations are now smooth. Tried capturing on video, but it's a little hard to see at 30fps.