### PR TITLE
feat: Add Touhou Little Maid experience lantern compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,9 @@ dependencies {
 
     compileOnly("top.theillusivec4.curios:curios-neoforge:${curios_version}+${curios_minecraft_version}:api")
     localRuntime("top.theillusivec4.curios:curios-neoforge:${curios_version}+${curios_minecraft_version}")
+
+    // Touhou Little Maid integration (optional)
+    compileOnly("curse.maven:touhou-little-maid-355044:${tlm_file_id}")
 }
 
 var generateModMetadata = tasks.register("generateModMetadata", ProcessResources) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,3 +32,5 @@ jei_minecraft_version = 1.21.1
 jei_version = 19.21.2.313
 curios_minecraft_version = 1.21.1
 curios_version = 9.2.2
+# Touhou Little Maid (optional)
+tlm_file_id = 7307724

--- a/src/main/java/plus/dragons/createenchantmentindustry/common/fluids/lantern/ExperienceLanternBlockEntity.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/common/fluids/lantern/ExperienceLanternBlockEntity.java
@@ -44,6 +44,7 @@ import plus.dragons.createdragonsplus.common.fluids.tank.FluidTankBehaviour;
 import plus.dragons.createenchantmentindustry.common.fluids.experience.ExperienceHelper;
 import plus.dragons.createenchantmentindustry.common.registry.CEIFluids;
 import plus.dragons.createenchantmentindustry.config.CEIConfig;
+import plus.dragons.createenchantmentindustry.integration.tlm.TLMCompat;
 
 public class ExperienceLanternBlockEntity extends SmartBlockEntity implements IHaveGoggleInformation {
     protected FluidTankBehaviour tank;
@@ -129,6 +130,19 @@ public class ExperienceLanternBlockEntity extends SmartBlockEntity implements IH
                 }
             }
         }
+        // Drain experience from Touhou Little Maid's maids if the mod is loaded
+        if (TLMCompat.isLoaded() && CEIConfig.fluids().experienceLanternDrainMaidExperience.get()) {
+            drainMaidExp();
+        }
+    }
+
+    /**
+     * Drain experience from nearby Touhou Little Maid's maids.
+     * This method is only called when TLM mod is loaded.
+     */
+    protected void drainMaidExp() {
+        plus.dragons.createenchantmentindustry.integration.tlm.MaidExperienceHandler
+                .drainMaidExperience(level, effectiveAABB, tank.getPrimaryHandler());
     }
 
     protected void pullExp() {

--- a/src/main/java/plus/dragons/createenchantmentindustry/common/fluids/lantern/ExperienceLanternMovementBehaviour.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/common/fluids/lantern/ExperienceLanternMovementBehaviour.java
@@ -34,6 +34,7 @@ import net.neoforged.neoforge.fluids.capability.IFluidHandler;
 import plus.dragons.createenchantmentindustry.common.fluids.experience.ExperienceHelper;
 import plus.dragons.createenchantmentindustry.common.registry.CEIFluids;
 import plus.dragons.createenchantmentindustry.config.CEIConfig;
+import plus.dragons.createenchantmentindustry.integration.tlm.TLMCompat;
 
 public class ExperienceLanternMovementBehaviour implements MovementBehaviour {
     @Override
@@ -105,6 +106,11 @@ public class ExperienceLanternMovementBehaviour implements MovementBehaviour {
                     break;
                 }
             }
+        }
+        // Drain experience from Touhou Little Maid's maids if the mod is loaded
+        if (TLMCompat.isLoaded() && CEIConfig.fluids().experienceLanternDrainMaidExperience.get()) {
+            plus.dragons.createenchantmentindustry.integration.tlm.MaidExperienceHandler
+                    .drainMaidExperience(level, effectiveAABB, tank);
         }
     }
 

--- a/src/main/java/plus/dragons/createenchantmentindustry/config/CEIFluidsConfig.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/config/CEIFluidsConfig.java
@@ -93,6 +93,9 @@ public class CEIFluidsConfig extends ConfigBase {
     public final ConfigFloat experienceLanternPullForceMultiplier = f(.075f, 0.0f, .5f,
             "experienceLanternPullForceMultiplier",
             Comments.experienceLanternPullForceMultiplier);
+    public final ConfigBool experienceLanternDrainMaidExperience = b(true,
+            "experienceLanternDrainMaidExperience",
+            Comments.experienceLanternDrainMaidExperience);
     public final ConfigInt mechanicalGrindstoneFluidCapacity = i(1000, 5000,
             "mechanicalGrindstoneFluidCapacity",
             Comments.mechanicalGrindstoneFluidCapacity,
@@ -126,6 +129,7 @@ public class CEIFluidsConfig extends ConfigBase {
         static final String experienceLanternPullToggle = "Whether the Experience Lantern will pull in experience orbs from nearby.";
         static final String experienceLanternPullRadius = "The range at which experience orbs will be pulled into the lantern.";
         static final String experienceLanternPullForceMultiplier = "Modifier for the amount of force with which to pull the experience orbs.";
+        static final String experienceLanternDrainMaidExperience = "Whether the Experience Lantern will drain experience from nearby Touhou Little Maid's maids (requires TLM mod).";
         static final String mechanicalGrindstoneFluidCapacity = "The amount of liquid a Grindstone Drain can hold (mB).";
     }
 }

--- a/src/main/java/plus/dragons/createenchantmentindustry/integration/tlm/MaidExperienceHandler.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/integration/tlm/MaidExperienceHandler.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2025  DragonsPlus
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package plus.dragons.createenchantmentindustry.integration.tlm;
+
+import com.github.tartaricacid.touhoulittlemaid.entity.passive.EntityMaid;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.AABB;
+import net.neoforged.neoforge.fluids.FluidStack;
+import net.neoforged.neoforge.fluids.capability.IFluidHandler;
+import plus.dragons.createenchantmentindustry.common.registry.CEIFluids;
+import plus.dragons.createenchantmentindustry.config.CEIConfig;
+
+/**
+ * Handler for draining experience from Touhou Little Maid's EntityMaid.
+ * This class is only loaded when TLM is present.
+ */
+public class MaidExperienceHandler {
+    /**
+     * Drain experience from nearby maids and fill into the fluid handler.
+     *
+     * @param level         the world level
+     * @param effectiveAABB the area to search for maids
+     * @param fluidHandler  the fluid handler to fill experience into
+     * @return the total amount of experience drained
+     */
+    public static int drainMaidExperience(Level level, AABB effectiveAABB, IFluidHandler fluidHandler) {
+        var rate = CEIConfig.fluids().experienceLanternDrainRate.get();
+        List<EntityMaid> maids = level.getEntitiesOfClass(EntityMaid.class, effectiveAABB,
+                maid -> maid.isAlive() && maid.getExperience() > 0);
+
+        if (maids.isEmpty()) {
+            return 0;
+        }
+
+        AtomicInteger totalDrained = new AtomicInteger();
+
+        // Calculate the total experience we can drain
+        AtomicInteger sum = new AtomicInteger();
+        maids.forEach(maid -> {
+            var maidExp = maid.getExperience();
+            if (maidExp >= rate) {
+                sum.addAndGet(rate);
+            } else if (maidExp > 0) {
+                sum.addAndGet(maidExp);
+            }
+        });
+
+        if (sum.get() == 0) {
+            return 0;
+        }
+
+        // Try to insert the experience fluid
+        var inserted = fluidHandler.fill(new FluidStack(CEIFluids.EXPERIENCE, sum.get()), IFluidHandler.FluidAction.EXECUTE);
+
+        if (inserted > 0) {
+            // Distribute the drain across maids
+            int remaining = inserted;
+            for (var maid : maids) {
+                if (remaining <= 0) break;
+
+                var maidExp = maid.getExperience();
+                int toDrain;
+
+                if (remaining >= rate) {
+                    toDrain = Math.min(maidExp, rate);
+                } else {
+                    toDrain = Math.min(maidExp, remaining);
+                }
+
+                if (toDrain > 0) {
+                    maid.setExperience(maidExp - toDrain);
+                    remaining -= toDrain;
+                    totalDrained.addAndGet(toDrain);
+                }
+            }
+        }
+
+        return totalDrained.get();
+    }
+}

--- a/src/main/java/plus/dragons/createenchantmentindustry/integration/tlm/TLMCompat.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/integration/tlm/TLMCompat.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025  DragonsPlus
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package plus.dragons.createenchantmentindustry.integration.tlm;
+
+import net.neoforged.fml.ModList;
+
+/**
+ * Compatibility utility class for Touhou Little Maid mod.
+ */
+public class TLMCompat {
+    public static final String MOD_ID = "touhou_little_maid";
+    private static Boolean loaded = null;
+
+    /**
+     * Check if Touhou Little Maid mod is loaded.
+     *
+     * @return true if TLM is present
+     */
+    public static boolean isLoaded() {
+        if (loaded == null) {
+            loaded = ModList.get().isLoaded(MOD_ID);
+        }
+        return loaded;
+    }
+}

--- a/src/main/java/plus/dragons/createenchantmentindustry/integration/tlm/package-info.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/integration/tlm/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2025 DragonsPlus
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Integration with Touhou Little Maid mod.
+ */
+package plus.dragons.createenchantmentindustry.integration.tlm;

--- a/src/main/templates/META-INF/neoforge.mods.toml
+++ b/src/main/templates/META-INF/neoforge.mods.toml
@@ -51,3 +51,10 @@ issueTrackerURL="${mod_github}/issues"
     versionRange="${create_dragons_plus_version_range}"
     ordering="NONE"
     side="BOTH"
+
+[[dependencies.${mod_id}]]
+    modId="touhou_little_maid"
+    type="optional"
+    versionRange="[1.2.0,)"
+    ordering="AFTER"
+    side="BOTH"


### PR DESCRIPTION
## Summary

This PR adds compatibility between Experience Lantern and [Touhou Little Maid](https://www.curseforge.com/minecraft/mc-mods/touhou-little-maid) mod, allowing the Experience Lantern to drain experience from nearby maids.

## Changes

### New Features
- Experience Lantern can now drain experience from nearby TLM maids (EntityMaid)
- Works both when the lantern is placed as a block and when mounted on contraptions
- Added configuration option `experienceLanternDrainMaidExperience` (default: `true`) to toggle this feature

### Technical Details
- TLM is added as an **optional soft dependency** - the mod works perfectly without it
- Uses `ModList.get().isLoaded()` for runtime detection
- New integration package: `integration.tlm`
  - `TLMCompat.java` - Mod detection utility
  - `MaidExperienceHandler.java` - Handles draining maid experience
  - `package-info.java`

### Files Modified
- `build.gradle` - Added TLM compile-only dependency
- `gradle.properties` - Added TLM file ID
- `neoforge.mods.toml` - Added optional dependency declaration
- `CEIFluidsConfig.java` - Added config option
- `ExperienceLanternBlockEntity.java` - Added maid experience draining
- `ExperienceLanternMovementBehaviour.java` - Added maid experience draining for contraptions

## Testing
- ✅ Tested in-game with TLM 1.4.6 on NeoForge 1.21.1
- ✅ Verified experience is properly drained from maids
- ✅ Verified config toggle works correctly
- ✅ Verified mod works without TLM installed

## Related
- Touhou Little Maid API documentation: http://page.cfpa.team/TouhouLittleMaid/wiki/dev/start/