### PR TITLE
Fix Ponder crashes by targeting Fluid Tank controllers instead of dummy blocks

### DIFF
--- a/src/main/java/plus/dragons/createenchantmentindustry/client/ponder/scene/ExperienceScene.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/client/ponder/scene/ExperienceScene.java
@@ -66,7 +66,7 @@ public class ExperienceScene {
                 .placeNearTarget()
                 .pointAt(util.vector().centerOf(9, 5, 9));
         for (int i = 0; i < 6; i++) {
-            scene.world().modifyBlockEntity(util.grid().at(9, 4, 9), FluidTankBlockEntity.class,
+            scene.world().modifyBlockEntity(util.grid().at(9, 1, 9), FluidTankBlockEntity.class,
                     be -> be.getControllerBE().getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 10000), IFluidHandler.FluidAction.EXECUTE));
             scene.idle(10);
         }

--- a/src/main/java/plus/dragons/createenchantmentindustry/client/ponder/scene/MiscScene.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/client/ponder/scene/MiscScene.java
@@ -68,7 +68,7 @@ public class MiscScene {
                 .add(-.125, 0, 0);
         scene.overlay().showControls(frontVec, Pointing.UP, 50).rightClick();
         scene.idle(10);
-        scene.world().modifyBlockEntity(util.grid().at(2, 3, 2), FluidTankBlockEntity.class,
+        scene.world().modifyBlockEntity(util.grid().at(2, 2, 2), FluidTankBlockEntity.class,
                 be -> be.getControllerBE().getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 10000), IFluidHandler.FluidAction.EXECUTE));
         scene.idle(50);
 
@@ -95,7 +95,7 @@ public class MiscScene {
                 .placeNearTarget()
                 .pointAt(util.vector().centerOf(1, 3, 2));
         for (int i = 0; i < 12; i++) {
-            scene.world().modifyBlockEntity(util.grid().at(2, 3, 2), FluidTankBlockEntity.class,
+            scene.world().modifyBlockEntity(util.grid().at(2, 2, 2), FluidTankBlockEntity.class,
                     be -> be.getControllerBE().getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 1000), IFluidHandler.FluidAction.EXECUTE));
             scene.idle(5);
         }


### PR DESCRIPTION
This PR fixes a `NullPointerException` that occurs when players attempt to view Ponder scenes for the Experience Hatch or Liquid Experience.

This error occurred when I tried to view the "pounder" of the experience hatch.

In the Ponder virtual world, calling the `getControllerBE()` function on a "dummy" object (that is not a controller) often returns a `null` value because the connection to the world may not be fully established. Attempting to call `.getTankInventory()` with this `null` result causes the client to crash immediately.

I fixed the coordinates in the `modifyBlockEntity` calls to point to the actual tank structure controller block (the block with the minimum X, Y, and Z coordinates in the structure).

The `getControllerBE()` function in the controller block returns the `this` value, which avoids issues with searching in the world and prevents crashes, allowing the liquid to visually fill and flow out.

I change next snippets:
`MiscScene.java`: changed target coordinates from (2, 3, 2) to (2, 2, 2) for the **Experience Hatch tank**.
`ExperienceScene.java`: changed target coordinates from (9, 4, 9) to (9, 1, 9) for the large **Liquid Experience tank**.

Fixes was verified in-game on Minecraft 1.21.1. Both Ponder scenes now play correctly with fluid animations and no crashes.

Screenshot next shows passing "broken" keyframe:
<img width="1201" height="1122" alt="image" src="https://github.com/user-attachments/assets/f0d3d730-0ffa-4aae-9b16-41db69cef2ef" />

Fixes the Ponder crash part of #423.

