### PR TITLE
fix: Correct text when not enough experience is available in Blaze Enchanter.

### DIFF
--- a/src/main/java/plus/dragons/createenchantmentindustry/common/processing/enchanter/EnchanterBehaviour.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/common/processing/enchanter/EnchanterBehaviour.java
@@ -211,9 +211,13 @@ public class EnchanterBehaviour extends ScrollValueBehaviour implements IHaveGog
             added = true;
         }
         if (!enchanter.heldItem.isEmpty() && enchanter.processingTime == -1) {
-            if (!EnchantmentHelper.getEnchantmentsForCrafting(enchanter.heldItem).isEmpty())
+            if (!EnchantmentHelper.getEnchantmentsForCrafting(enchanter.heldItem).isEmpty()) {
                 CEILang.translate("gui.goggles.enchanting.completed").style(ChatFormatting.GREEN).forGoggles(tooltip);
-            else CEILang.translate("gui.goggles.enchanting.invalid_item").style(ChatFormatting.RED).forGoggles(tooltip);
+            } else if (cost > 0 && enchanter.tanks.getTank(0).getFluidAmount() < cost) {
+                CEILang.translate("gui.goggles.enchanting.insufficient_experience").style(ChatFormatting.RED).forGoggles(tooltip);
+            } else { 
+                CEILang.translate("gui.goggles.enchanting.invalid_item").style(ChatFormatting.RED).forGoggles(tooltip);
+            }
         }
         return added;
     }

--- a/src/main/java/plus/dragons/createenchantmentindustry/common/processing/enchanter/EnchanterBehaviour.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/common/processing/enchanter/EnchanterBehaviour.java
@@ -213,9 +213,12 @@ public class EnchanterBehaviour extends ScrollValueBehaviour implements IHaveGog
         if (!enchanter.heldItem.isEmpty() && enchanter.processingTime == -1) {
             if (!EnchantmentHelper.getEnchantmentsForCrafting(enchanter.heldItem).isEmpty()) {
                 CEILang.translate("gui.goggles.enchanting.completed").style(ChatFormatting.GREEN).forGoggles(tooltip);
-            } else if (cost > 0 && enchanter.tanks.getTank(0).getFluidAmount() < cost) {
-                CEILang.translate("gui.goggles.enchanting.insufficient_experience").style(ChatFormatting.RED).forGoggles(tooltip);
-            } else { 
+            } else if (cost > 0) {
+                int experience = enchanter.special ? enchanter.getSpecialExperience() : enchanter.getNormalExperience();
+                if (experience < cost) {
+                    CEILang.translate("gui.goggles.enchanting.insufficient_experience").style(ChatFormatting.RED).forGoggles(tooltip);
+                }
+            } else {
                 CEILang.translate("gui.goggles.enchanting.invalid_item").style(ChatFormatting.RED).forGoggles(tooltip);
             }
         }

--- a/src/main/resources/assets/create_enchantment_industry/lang/builtin/interface.json
+++ b/src/main/resources/assets/create_enchantment_industry/lang/builtin/interface.json
@@ -11,6 +11,7 @@
   "create_enchantment_industry.gui.goggles.enchanting.cost": "Enchanting consumes: %1$s",
   "create_enchantment_industry.gui.goggles.enchanting.completed": "Enchanting Completed!",
   "create_enchantment_industry.gui.goggles.enchanting.invalid_item": "Invalid enchanting item!",
+  "create_enchantment_industry.gui.goggles.enchanting.insufficient_experience": "Insufficient experience available!",
   "create_enchantment_industry.gui.goggles.forging.cost": "Forging consumes: %1$s",
   "create_enchantment_industry.gui.goggles.forging.result": "Forging Result:",
   "create_enchantment_industry.gui.goggles.forging.invalid_template_type.normal": "Normal Enchanting Template can't be used in Super Enchanting mode!",

--- a/src/main/resources/assets/create_enchantment_industry/lang/builtin/interface.json
+++ b/src/main/resources/assets/create_enchantment_industry/lang/builtin/interface.json
@@ -11,7 +11,7 @@
   "create_enchantment_industry.gui.goggles.enchanting.cost": "Enchanting consumes: %1$s",
   "create_enchantment_industry.gui.goggles.enchanting.completed": "Enchanting Completed!",
   "create_enchantment_industry.gui.goggles.enchanting.invalid_item": "Invalid enchanting item!",
-  "create_enchantment_industry.gui.goggles.enchanting.insufficient_experience": "Insufficient experience available!",
+  "create_enchantment_industry.gui.goggles.enchanting.insufficient_experience": "Not enough experience!",
   "create_enchantment_industry.gui.goggles.forging.cost": "Forging consumes: %1$s",
   "create_enchantment_industry.gui.goggles.forging.result": "Forging Result:",
   "create_enchantment_industry.gui.goggles.forging.invalid_template_type.normal": "Normal Enchanting Template can't be used in Super Enchanting mode!",


### PR DESCRIPTION
Fixes #427, will now say "Not enough experience!" instead of "Invalid enchanting item!".