### PR TITLE
Fix ponder crash in create_enchantment_industry:experience_hatch and other problem

### DIFF
--- a/src/main/java/plus/dragons/createenchantmentindustry/client/ponder/scene/EnchanterScene.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/client/ponder/scene/EnchanterScene.java
@@ -57,14 +57,20 @@ public class EnchanterScene {
                 .text("This is a Blaze Enchanter, which functions like an Enchanting Table")
                 .placeNearTarget()
                 .pointAt(util.vector().topOf(2, 2, 1));
-        scene.world().modifyBlockEntity(util.grid().at(3, 1, 3), FluidTankBlockEntity.class,
-                be -> be.getControllerBE().getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 24000), IFluidHandler.FluidAction.EXECUTE));
+        scene.world().modifyBlockEntity(util.grid().at(3, 1, 3), FluidTankBlockEntity.class, be -> {
+            var ctrl = be.getControllerBE();
+            if (ctrl != null) ctrl.getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 24000), IFluidHandler.FluidAction.EXECUTE);
+        });
         scene.idle(20);
-        scene.world().modifyBlockEntity(util.grid().at(1, 1, 3), FluidTankBlockEntity.class,
-                be -> be.getControllerBE().getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 9000), IFluidHandler.FluidAction.EXECUTE));
+        scene.world().modifyBlockEntity(util.grid().at(1, 1, 3), FluidTankBlockEntity.class, be -> {
+            var ctrl = be.getControllerBE();
+            if (ctrl != null) ctrl.getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 9000), IFluidHandler.FluidAction.EXECUTE);
+        });
         scene.idle(20);
-        scene.world().modifyBlockEntity(util.grid().at(2, 1, 3), FluidTankBlockEntity.class,
-                be -> be.getControllerBE().getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 17000), IFluidHandler.FluidAction.EXECUTE));
+        scene.world().modifyBlockEntity(util.grid().at(2, 1, 3), FluidTankBlockEntity.class, be -> {
+            var ctrl = be.getControllerBE();
+            if (ctrl != null) ctrl.getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 17000), IFluidHandler.FluidAction.EXECUTE);
+        });
         scene.idle(30);
 
         scene.overlay().showText(60)

--- a/src/main/java/plus/dragons/createenchantmentindustry/client/ponder/scene/ExperienceScene.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/client/ponder/scene/ExperienceScene.java
@@ -66,8 +66,10 @@ public class ExperienceScene {
                 .placeNearTarget()
                 .pointAt(util.vector().centerOf(9, 5, 9));
         for (int i = 0; i < 6; i++) {
-            scene.world().modifyBlockEntity(util.grid().at(9, 4, 9), FluidTankBlockEntity.class,
-                    be -> be.getControllerBE().getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 10000), IFluidHandler.FluidAction.EXECUTE));
+            scene.world().modifyBlockEntity(util.grid().at(9, 4, 9), FluidTankBlockEntity.class, be -> {
+                var ctrl = be.getControllerBE();
+                if (ctrl != null) ctrl.getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 10000), IFluidHandler.FluidAction.EXECUTE);
+            });
             scene.idle(10);
         }
         scene.idle(10);

--- a/src/main/java/plus/dragons/createenchantmentindustry/client/ponder/scene/ForgerScene.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/client/ponder/scene/ForgerScene.java
@@ -59,11 +59,15 @@ public class ForgerScene {
         scene.world().setKineticSpeed(util.select().position(4, 1, 2), 128);
         scene.world().setKineticSpeed(util.select().position(3, 2, 3), -128);
         scene.idle(20);
-        scene.world().modifyBlockEntity(util.grid().at(1, 1, 3), FluidTankBlockEntity.class,
-                be -> be.getControllerBE().getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 8000), IFluidHandler.FluidAction.EXECUTE));
+        scene.world().modifyBlockEntity(util.grid().at(1, 1, 3), FluidTankBlockEntity.class, be -> {
+            var ctrl = be.getControllerBE();
+            if (ctrl != null) ctrl.getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 8000), IFluidHandler.FluidAction.EXECUTE);
+        });
         scene.idle(20);
-        scene.world().modifyBlockEntity(util.grid().at(1, 1, 3), FluidTankBlockEntity.class,
-                be -> be.getControllerBE().getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 8000), IFluidHandler.FluidAction.EXECUTE));
+        scene.world().modifyBlockEntity(util.grid().at(1, 1, 3), FluidTankBlockEntity.class, be -> {
+            var ctrl = be.getControllerBE();
+            if (ctrl != null) ctrl.getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 8000), IFluidHandler.FluidAction.EXECUTE);
+        });
         scene.idle(30);
 
         scene.overlay().showText(60)

--- a/src/main/java/plus/dragons/createenchantmentindustry/client/ponder/scene/MiscScene.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/client/ponder/scene/MiscScene.java
@@ -68,8 +68,10 @@ public class MiscScene {
                 .add(-.125, 0, 0);
         scene.overlay().showControls(frontVec, Pointing.UP, 50).rightClick();
         scene.idle(10);
-        scene.world().modifyBlockEntity(util.grid().at(2, 3, 2), FluidTankBlockEntity.class,
-                be -> be.getControllerBE().getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 10000), IFluidHandler.FluidAction.EXECUTE));
+        scene.world().modifyBlockEntity(util.grid().at(2, 3, 2), FluidTankBlockEntity.class, be -> {
+            var ctrl = be.getControllerBE();
+            if (ctrl != null) ctrl.getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 10000), IFluidHandler.FluidAction.EXECUTE);
+        });
         scene.idle(50);
 
         scene.world().modifyBlockEntity(util.grid().at(3, 2, 1), BasinBlockEntity.class,
@@ -95,8 +97,10 @@ public class MiscScene {
                 .placeNearTarget()
                 .pointAt(util.vector().centerOf(1, 3, 2));
         for (int i = 0; i < 12; i++) {
-            scene.world().modifyBlockEntity(util.grid().at(2, 3, 2), FluidTankBlockEntity.class,
-                    be -> be.getControllerBE().getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 1000), IFluidHandler.FluidAction.EXECUTE));
+            scene.world().modifyBlockEntity(util.grid().at(2, 3, 2), FluidTankBlockEntity.class, be -> {
+                var ctrl = be.getControllerBE();
+                if (ctrl != null) ctrl.getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 1000), IFluidHandler.FluidAction.EXECUTE);
+            });
             scene.idle(5);
         }
         scene.idle(30);
@@ -110,8 +114,10 @@ public class MiscScene {
         scene.world().showSection(util.select().position(0, 1, 1), Direction.DOWN);
         scene.idle(20);
 
-        scene.world().modifyBlockEntity(util.grid().at(1, 1, 1), FluidTankBlockEntity.class,
-                be -> be.getControllerBE().getTankInventory().fill(new FluidStack(CDPFluids.DYES_BY_COLOR.get(DyeColor.CYAN).get(), 36000), IFluidHandler.FluidAction.EXECUTE));
+        scene.world().modifyBlockEntity(util.grid().at(1, 1, 1), FluidTankBlockEntity.class, be -> {
+            var ctrl = be.getControllerBE();
+            if (ctrl != null) ctrl.getTankInventory().fill(new FluidStack(CDPFluids.DYES_BY_COLOR.get(DyeColor.CYAN).get(), 36000), IFluidHandler.FluidAction.EXECUTE);
+        });
         scene.idle(10);
         scene.overlay().showText(40)
                 .text("For example, assume that Liquid Cyan Dye is experience fluid from another mod")
@@ -130,8 +136,10 @@ public class MiscScene {
                 .placeNearTarget()
                 .pointAt(util.vector().centerOf(0, 1, 1));
         for (int i = 0; i < 12; i++) {
-            scene.world().modifyBlockEntity(util.grid().at(1, 1, 1), FluidTankBlockEntity.class,
-                    be -> be.getControllerBE().getTankInventory().drain(new FluidStack(CDPFluids.DYES_BY_COLOR.get(DyeColor.CYAN).get(), 3000), IFluidHandler.FluidAction.EXECUTE));
+            scene.world().modifyBlockEntity(util.grid().at(1, 1, 1), FluidTankBlockEntity.class, be -> {
+                var ctrl = be.getControllerBE();
+                if (ctrl != null) ctrl.getTankInventory().drain(new FluidStack(CDPFluids.DYES_BY_COLOR.get(DyeColor.CYAN).get(), 3000), IFluidHandler.FluidAction.EXECUTE);
+            });
             scene.idle(10);
         }
     }
@@ -280,11 +288,15 @@ public class MiscScene {
         scene.world().rotateBearing(util.grid().at(2, 4, 2), -360, 140);
         scene.world().rotateSection(contraption, 0, -360, 0, 140);
         scene.idle(30);
-        scene.world().modifyBlockEntity(util.grid().at(2, 1, 3), FluidTankBlockEntity.class,
-                be -> be.getControllerBE().getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 2000), IFluidHandler.FluidAction.EXECUTE));
+        scene.world().modifyBlockEntity(util.grid().at(2, 1, 3), FluidTankBlockEntity.class, be -> {
+            var ctrl = be.getControllerBE();
+            if (ctrl != null) ctrl.getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 2000), IFluidHandler.FluidAction.EXECUTE);
+        });
         scene.idle(40);
-        scene.world().modifyBlockEntity(util.grid().at(2, 1, 3), FluidTankBlockEntity.class,
-                be -> be.getControllerBE().getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 2000), IFluidHandler.FluidAction.EXECUTE));
+        scene.world().modifyBlockEntity(util.grid().at(2, 1, 3), FluidTankBlockEntity.class, be -> {
+            var ctrl = be.getControllerBE();
+            if (ctrl != null) ctrl.getTankInventory().fill(new FluidStack(CEIFluids.EXPERIENCE.get(), 2000), IFluidHandler.FluidAction.EXECUTE);
+        });
         scene.idle(70);
         scene.world().setKineticSpeed(util.select().fromTo(2, 4, 2, 2, 5, 2), 0);
     }


### PR DESCRIPTION
This fixes a crash that happened when I used Ponder on create_enchantment_industry:experience_hatch while Create: Aeronautics was installed.

The issue was that FluidTankBlockEntity#getControllerBE() can be null in Ponder scenes in the Aeronautics/Sable setup, but the code was calling getTankInventory() directly and crashing.

I added null checks in these scenes so they handle that case safely:
MiscScene
ForgerScene
ExperienceScene
EnchanterScene

After this change, Ponder should open normally instead of crashing when Create: Aeronautics is installed.

I tested it locally and the crash is gone.