### PR TITLE
Fix math in getExperienceForTotalLevel for levels between 16 and 30

### DIFF
--- a/src/main/java/plus/dragons/createenchantmentindustry/common/fluids/experience/ExperienceHelper.java
+++ b/src/main/java/plus/dragons/createenchantmentindustry/common/fluids/experience/ExperienceHelper.java
@@ -50,7 +50,7 @@ public class ExperienceHelper {
         if (level >= 31)
             return (9 * level * level - 325 * level) / 2 + 2220;
         if (level >= 16)
-            return (5 * level * level - 91 * level) / 2 + 360;
+            return (5 * level * level - 81 * level) / 2 + 360;
         return level * level + 6 * level;
     }
 


### PR DESCRIPTION
According to the Minecraft Wiki, the formula we can use to calculate the amount of experience needed to go from level 0 to x, for any x between 16 and 30 is: 2.5x^2 - 40.5x + 360.

To avoid dealing with float math, the mod multiplies the whole expression by 2, then divides the result by 2 and simplifies wherever possible. The problem is that while calculating the new expression, the 40.5x term turned into 91x instead of 81x. This PR corrects that mistake.